### PR TITLE
Added sensible headers to _headers in gatsby-theme-try-ghost package

### DIFF
--- a/packages/gatsby-theme-try-ghost/static/_headers
+++ b/packages/gatsby-theme-try-ghost/static/_headers
@@ -1,0 +1,18 @@
+# This is recommended to prevent the caching of the service worker file itself
+# https://www.netlify.com/blog/2018/06/28/5-pro-tips-and-plugins-for-optimizing-your-gatsby---netlify-site/#4-get-your-service-workers-um-working
+/sw.js   # Gatsby's default service worker file path
+  Cache-Control: no-cache
+
+/rss
+  content-type: application/rss+xml; charset=UTF-8
+
+# These are default recommended security headers, for Netlify
+# https://www.netlify.com/docs/headers-and-basic-auth/
+
+/*
+  Referrer-Policy: no-referrer-when-downgrade
+  Strict-Transport-Security: max-age=31536000
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  X-Xss-Protection:	1; mode=block
+  Feature-Policy: accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'


### PR DESCRIPTION
I've had to manually reset my service workers after a new build was published through Netlify. This set of headers, taken from `TryGhost/gatsby-starter-ghost` seems to solve the issue.