### PR TITLE
Fixing issue where the logo is hard linked to the cmsURL rather than …

### DIFF
--- a/packages/gatsby-theme-ghost-members/src/components/common/SubscribeOverlay.js
+++ b/packages/gatsby-theme-ghost-members/src/components/common/SubscribeOverlay.js
@@ -21,10 +21,15 @@ const SubscribeOverlay = ({ data, overlay }) => {
     }
     const text = get(useLang())
     const site = data.ghostSettings
+    const cmsUrl = site.url
     const title = text(`SITE_TITLE`, site.title)
     const { isOpen, value, message } = overlay.state
     const openingStyle = { opacity: 1, pointerEvents: `auto` }
     const closingStyle = { opacity: 0, pointerEvents: null }
+
+    if (site.logo) {
+        site.logo = site.logo.replace(cmsUrl, '');
+    }
 
     return (
         <div className="subscribe-overlay" style={ isOpen ? openingStyle : closingStyle } >


### PR DESCRIPTION
…relative to base

Removes the cmsUrl from the site logo, so that it can load relatively.