### PR TITLE
Fixing referenced properties

### DIFF
--- a/packages/gatsby-theme-ghost-members/package.json
+++ b/packages/gatsby-theme-ghost-members/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gatsby-theme-ghost-members",
     "description": "Gatsby theme to easily add a members form to gatsby-theme-try-ghost",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "license": "MIT",
     "author": "styxlab",
     "homepage": "https://github.com/styxlab/",

--- a/packages/gatsby-theme-ghost-members/src/components/common/SubscribeOverlay.js
+++ b/packages/gatsby-theme-ghost-members/src/components/common/SubscribeOverlay.js
@@ -76,6 +76,9 @@ const SubscribeOverlayQuery = props => (
                 ghostSettings {
                     title
                     logo
+                    logoSharp {
+                        publicURL
+                    }
                 }
             }
         `}


### PR DESCRIPTION
I still found this didn't work, looked into why seems the properties used were not in the GraphQL query, have added and bumped the package version.