### PR TITLE
Fix ghost images plugin

### DIFF
--- a/packages/gatsby-plugin-ghost-images/gatsby-node.js
+++ b/packages/gatsby-plugin-ghost-images/gatsby-node.js
@@ -79,7 +79,7 @@ exports.onCreateNode = async function ({
 
   fileNodes.map((fileNode, i) => {
     const id = `${_.camelCase(`${allImgTags[i]}${ext}`)}`;
-    node[id] = fileNode.id;
+    node[`${id}___NODE`] = fileNode.id;
   });
   return {};
 };

--- a/packages/gatsby-plugin-ghost-images/src/gatsby-node.js
+++ b/packages/gatsby-plugin-ghost-images/src/gatsby-node.js
@@ -71,7 +71,7 @@ exports.onCreateNode = async function ({
     fileNodes.map((fileNode, i) => {
         const id = `${_.camelCase(`${allImgTags[i]}${ext}`)}`
 
-        node[id] = fileNode.id
+        node[`${id}___NODE`] = fileNode.id
     })
 
     return {}


### PR DESCRIPTION
Using gatsby-plugin-ghost-images outside of this project (with a self-hosted ghost blog) was not generating the proper GraphQL nodes. Took me all day, but this commit fixes this problem.