### PR TITLE
fix sharp image not linked to node

### DIFF
--- a/packages/gatsby-plugin-ghost-images/gatsby-node.js
+++ b/packages/gatsby-plugin-ghost-images/gatsby-node.js
@@ -78,7 +78,7 @@ exports.onCreateNode = async function ({
 
 
   fileNodes.map((fileNode, i) => {
-    const id = `${_.camelCase(`${allImgTags[i]}${ext}`)}`;
+    const id = `${_.camelCase(`${allImgTags[i]}${ext}`)}___NODE`;
     node[id] = fileNode.id;
   });
   return {};


### PR DESCRIPTION
`image fields` not returning remote file fields, it's returning raw node id instead. Query using image fields will return this kind of error, because it's string

![image](https://user-images.githubusercontent.com/9798995/113153476-55914980-9261-11eb-95ae-993e875f8309.png)

## Solution

[gatsby-source-filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/#example-usage-1) require linked node to add `___NODE`  on end of field.