### PR TITLE
Use ghostPost canonical url if available.

### DIFF
--- a/packages/gatsby-theme-try-ghost/src/components/common/meta/MetaData.js
+++ b/packages/gatsby-theme-try-ghost/src/components/common/meta/MetaData.js
@@ -21,11 +21,14 @@ const MetaData = ({
     location,
 }) => {
     const config = settings.site.siteMetadata
-    const canonical = url.resolve(config.siteUrl, location.pathname)
+    let canonical = url.resolve(config.siteUrl, location.pathname)
     const { ghostPost, ghostTag, ghostAuthor, ghostPage } = data
     settings = settings.allGhostSettings.edges[0].node
 
     if (ghostPost) {
+        if (ghostPost.canonical_url) {
+            canonical = ghostPost.canonical_url
+        }
         return (
             <ArticleMeta
                 data={ghostPost}


### PR DESCRIPTION
A simple change to use canonical URL from a ghost post if it's available.
On a separate commit, add a new siteConfig option `gatsbyNodeQuery` to override the default one. 