### PR TITLE
feat: pass additional params for cusdis support, maintain backward co…

### DIFF
--- a/packages/gatsby-theme-try-ghost/src/templates/post.js
+++ b/packages/gatsby-theme-try-ghost/src/templates/post.js
@@ -38,6 +38,7 @@ const Post = ({ data, location, pageContext }) => {
     const toc = post.childHtmlRehype && post.childHtmlRehype.tableOfContents || []
     const htmlAst = post.childHtmlRehype && post.childHtmlRehype.htmlAst
     const transformedHtml = post.childHtmlRehype && post.childHtmlRehype.html
+    const url = resolveUrl(basePath, pageContext.collectionPaths[post.id], post.slug, post.url)
 
     // Collection paths must be retrieved from pageContext
     previewPosts.forEach(({ node }) => node.collectionPath = pageContext.collectionPaths[node.id])
@@ -105,13 +106,13 @@ const Post = ({ data, location, pageContext }) => {
                                 }
 
                                 <section className="post-full-content">
-                                    <TableOfContents toc={toc} url={resolveUrl(basePath, pageContext.collectionPaths[post.id], post.slug, post.url)}/>
+                                    <TableOfContents toc={toc} url={url}/>
                                     <RenderContent htmlAst={htmlAst} html={transformedHtml || post.html} />
                                 </section>
 
                                 <Subscribe />
 
-                                <Comments id={post.id}/>
+                                <Comments id={post.id} title={post.title} url={url}/>
 
                             </article>
                         </div>


### PR DESCRIPTION
extend data passed to comments to allow easier extension for other comment systems eg 

to use the cusdis comments system via `gatsby-plugin-cusdis` your would

and then update `gatsby-config.js` with

```js
        {
            resolve: `gatsby-plugin-cusdis`,
            options: {
                appId: `your-cusdis-id`,
                host: `your-cusdis-host`, // not required, default https://cusdis.com
            },
        },
```

and then add a shadow copy of `Comments.js` with

```js
import React from 'react'
import PropTypes from 'prop-types'
import Cusdis from 'gatsby-plugin-cusdis'

const Comments = ({ id, title, url }) => {
    const attrs = {
        pageId: id.substr(13),
        pageUrl: url,
        pageTitle: title,
        theme: `auto`,
    }

    return (
        <Cusdis attrs={attrs} />
    )
}

Comments.propTypes = {
    id: PropTypes.string,
    title: PropTypes.string,
    url: PropTypes.string,
}

export default Comments
```


