### PR TITLE
Illogic al gatsby ghost image v4 compat

### DIFF
--- a/packages/gatsby-plugin-ghost-images/src/gatsby-node.js
+++ b/packages/gatsby-plugin-ghost-images/src/gatsby-node.js
@@ -18,7 +18,7 @@ exports.onCreateNode = async function ({
     cache,
     store,
 }, pluginOptions) {
-    const { createNode } = actions
+    const { createNode, createNodeField } = actions
     const { lookup, exclude, verbose, disable } = _.merge({}, pluginDefaults, pluginOptions)
 
     // leave if node is excluded by user
@@ -71,7 +71,7 @@ exports.onCreateNode = async function ({
     fileNodes.map((fileNode, i) => {
         const id = `${_.camelCase(`${allImgTags[i]}${ext}`)}`
 
-        node[id] = fileNode.id
+        createNodeField({ node, name: id, value: fileNode.id })
     })
 
     return {}

--- a/packages/gatsby-source-try-ghost/create-schema-customization.js
+++ b/packages/gatsby-source-try-ghost/create-schema-customization.js
@@ -14,7 +14,7 @@ const typeDefs = `
         meta_description: String
         postCount: Int
         url: String
-        featureImageSharp: File @link
+        featureImageSharp: File @link(from: "fields.featureImageSharp")
     }
     type GhostAuthor implements Node @dontinfer {
         id: String
@@ -71,7 +71,7 @@ const typeDefs = `
         meta_title: String
         meta_description: String
         email_subject: String
-        featureImageSharp: File @link
+        featureImageSharp: File @link(from: "fields.featureImageSharp")
         childHtmlRehype: HtmlRehype @link
     }
     type GhostPage implements Node @dontinfer {
@@ -110,7 +110,7 @@ const typeDefs = `
         twitter_description: String
         meta_title: String
         meta_description: String
-        featureImageSharp: File @link
+        featureImageSharp: File @link(from: "fields.featureImageSharp")
         childHtmlRehype: HtmlRehype @link
     }
     type GhostSettings implements Node @dontinfer {


### PR DESCRIPTION
Make changes to gatsby-plugin-ghost-images to facilitate new v4 API changes: https://www.gatsbyjs.com/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4/#2-data-mutations-need-to-happen-during-sourcenodes-or-oncreatenode