### PR TITLE
Add optional checking on node.plugin when finding types

### DIFF
--- a/packages/gatsby-transformer-rehype/src/create-schema-customization.js
+++ b/packages/gatsby-transformer-rehype/src/create-schema-customization.js
@@ -9,7 +9,7 @@ const typeDefs = `
 // Is there a better way to check for existing types?
 const useTypeExists = (store, name) => (type) => {
     const types = store.getState().schemaCustomization.types
-    const plugin = types.find(node => node.plugin.name === name)
+    const plugin = types.find(node => node.plugin?.name === name)
 
     if (plugin === undefined) {
         return false


### PR DESCRIPTION
The plugin causes "TypeError: Cannot read property 'name' of undefined" on my Ghost project.

```
"gatsby": "^4.9.3",
"gatsby-transformer-rehype": "^2.0.1"
```